### PR TITLE
split the steps, because of timeout issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM debian:jessie
 
 RUN apt-get -y update
 RUN apt-get -y upgrade
+RUN apt-get install --yes gdebi-core
 RUN apt-get install --yes \
     curl \
     default-jre-headless \
     git \
-    gdebi-core \
     php5-cli \
     libapache2-mod-php5 \
     php-pear \


### PR DESCRIPTION
Downloading too many apt-get packages at once on CircleCI causes timeout issues. 